### PR TITLE
商品詳細表示機能実装

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Things you may want to cover:
 | explanation            | text       | null: false                    |
 | category_id            | integer    | null: false                    |
 | status_id              | integer    | null: false                    |
-| shipping_charges_id    | integer    | null: false                    |
+| shipping_charge_id    | integer    | null: false                    |
 | shipping_region_id     | integer    | null: false                    |
 | days_until_shipping_id | integer    | null: false                    |
 | price                  | integer    | null: false                    |

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -18,10 +18,14 @@ class ItemsController < ApplicationController
     end
   end
 
+  def show
+    @item = Item.find(params[:id])
+  end
+
   private
 
   def item_params
-    params.require(:item).permit(:name, :image, :explanation, :category_id, :status_id, :shipping_charges_id, :shipping_region_id, :days_until_shipping_id, :price).merge(user_id: current_user.id)
+    params.require(:item).permit(:name, :image, :explanation, :category_id, :status_id, :shipping_charge_id, :shipping_region_id, :days_until_shipping_id, :price).merge(user_id: current_user.id)
   end
 
   def move_to_index

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -17,7 +17,7 @@ class Item < ApplicationRecord
   validates :explanation, presence: true
   validates :category_id, numericality: { other_than: 1, message: 'Select' }
   validates :status_id, numericality: { other_than: 1, message: 'Select' }
-  validates :shipping_charges_id, numericality: { other_than: 1, message: 'Select' }
+  validates :shipping_charge_id, numericality: { other_than: 1, message: 'Select' }
   validates :shipping_region_id, numericality: { other_than: 1, message: 'Select' }
   validates :days_until_shipping_id, numericality: { other_than: 1, message: 'Select' }
   PRICE_REGEX = /\A[0-9]+\z/.freeze

--- a/app/models/shipping_region.rb
+++ b/app/models/shipping_region.rb
@@ -1,6 +1,6 @@
 class ShippingRegion < ActiveHash::Base
   self.data = [
-    { id: 1, name: '---' }, { id: 2, name: '北海道'}, {id: 3, name: '青森県'}, {id: 4, name: '岩手県'},
+    { id: 1, name: '---' }, { id: 2, name: '北海道' }, {id: 3, name: '青森県'}, {id: 4, name: '岩手県'},
     {id: 5, name: '宮城県'}, {id: 6, name: '秋田県'}, {id: 7, name: '山形県'},
     {id: 8, name: '福島県'}, {id: 9, name: '茨城県'}, {id: 10, name: '栃木県'},
     {id: 11, name: '群馬県'}, {id: 12, name: '埼玉県'}, {id: 13, name: '千葉県'},

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -128,7 +128,7 @@
     <% if @items.present? %>
     <% @items.each do |item| %>
       <li class='list'>
-        <%= link_to '#' do %>
+        <%= link_to item_path(item.id) do %>
         <div class='item-img-content'>
           <%= image_tag item.image, class: "item-img" %>
 

--- a/app/views/items/new.html.erb
+++ b/app/views/items/new.html.erb
@@ -69,7 +69,7 @@
           配送料の負担
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:shipping_charges_id, ShippingCharge.all, :id, :name, {}, {class:"select-box", id:"item-shipping-fee-status"}) %>
+        <%= f.collection_select(:shipping_charge_id, ShippingCharge.all, :id, :name, {}, {class:"select-box", id:"item-shipping-fee-status"}) %>
         <div class="weight-bold-text">
           発送元の地域
           <span class="indispensable">必須</span>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -101,7 +101,7 @@
       後ろの商品 ＞
     </a>
   </div>
-  <a href="#" class='another-item'><%= "商品のカテゴリー名" %>をもっと見る</a>
+  <a href="#" class='another-item'><%= @item.category.name %>をもっと見る</a>
 </div>
 
 <%= render "shared/footer" %>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -4,10 +4,10 @@
 <div class="item-show">
   <div class="item-box">
     <h2 class="name">
-      <%= "商品名" %>
+      <%= @item.name %>
     </h2>
     <div class='item-img-content'>
-      <%= image_tag "item-sample.png" ,class:"item-box-img" %>
+      <%= image_tag @item.image ,class:"item-box-img" %>
       <%# 商品が売れている場合は、sold outを表示しましょう %>
       <div class='sold-out'>
         <span>Sold Out!!</span>
@@ -16,22 +16,21 @@
     </div>
     <div class="item-price-box">
       <span class="item-price">
-        ¥ 999,999,999
+        ¥ <%= @item.price %>
       </span>
       <span class="item-postage">
         (税込) 送料込み
       </span>
     </div>
 
-    <%# ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
-
-    <%= link_to '商品の編集', "#", method: :get, class: "item-red-btn" %>
-    <p class='or-text'>or</p>
-    <%= link_to '削除', "#", method: :delete, class:'item-destroy' %>
-
-    <%# 商品が売れていない場合はこちらを表示しましょう %>
-    <%= link_to '購入画面に進む', "#" ,class:"item-red-btn"%>
-    <%# //商品が売れていない場合はこちらを表示しましょう %>
+    <% if user_signed_in? && current_user.id == @item.user_id %>
+      <%= link_to '商品の編集', "#", method: :get, class: "item-red-btn" %>
+      <p class='or-text'>or</p>
+      <%= link_to '削除', "#", method: :delete, class:'item-destroy' %>
+    <% end %>
+    <% if user_signed_in? && current_user.id != @item.user_id %>
+      <%= link_to '購入画面に進む', "#" ,class:"item-red-btn"%>
+    <% end %>
 
 
     <%# //ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
@@ -43,27 +42,27 @@
       <tbody>
         <tr>
           <th class="detail-item">出品者</th>
-          <td class="detail-value"><%= "出品者名" %></td>
+          <td class="detail-value"><%= @item.user.nickname %></td>
         </tr>
         <tr>
           <th class="detail-item">カテゴリー</th>
-          <td class="detail-value"><%= "カテゴリー名" %></td>
+          <td class="detail-value"><%= @item.category.name %></td>
         </tr>
         <tr>
           <th class="detail-item">商品の状態</th>
-          <td class="detail-value"><%= "商品の状態" %></td>
+          <td class="detail-value"><%= @item.status.name %></td>
         </tr>
         <tr>
           <th class="detail-item">配送料の負担</th>
-          <td class="detail-value"><%= "発送料の負担" %></td>
+          <td class="detail-value"><%= @item.shipping_charge.name %></td>
         </tr>
         <tr>
           <th class="detail-item">発送元の地域</th>
-          <td class="detail-value"><%= "発送元の地域" %></td>
+          <td class="detail-value"><%= @item.shipping_region.name %></td>
         </tr>
         <tr>
           <th class="detail-item">発送日の目安</th>
-          <td class="detail-value"><%= "発送日の目安" %></td>
+          <td class="detail-value"><%= @item.days_until_shipping.name %></td>
         </tr>
       </tbody>
     </table>

--- a/db/migrate/20200908073820_rename_shipping_charges_id_column_to_items.rb
+++ b/db/migrate/20200908073820_rename_shipping_charges_id_column_to_items.rb
@@ -1,0 +1,5 @@
+class RenameShippingChargesIdColumnToItems < ActiveRecord::Migration[6.0]
+  def change
+    rename_column :items, :shipping_charges_id, :shipping_charge_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_09_07_041620) do
+ActiveRecord::Schema.define(version: 2020_09_08_073820) do
 
   create_table "active_storage_attachments", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "name", null: false
@@ -38,7 +38,7 @@ ActiveRecord::Schema.define(version: 2020_09_07_041620) do
     t.text "explanation"
     t.integer "category_id"
     t.integer "status_id"
-    t.integer "shipping_charges_id"
+    t.integer "shipping_charge_id"
     t.integer "shipping_region_id"
     t.integer "days_until_shipping_id"
     t.integer "price"

--- a/spec/factories/items.rb
+++ b/spec/factories/items.rb
@@ -4,7 +4,7 @@ FactoryBot.define do
     explanation            { '10週間で人生が変わる、No.1エンジニア養成プログラム' }
     category_id            { '2' }
     status_id              { '2' }
-    shipping_charges_id    { '2' }
+    shipping_charge_id { '2' }
     shipping_region_id     { '2' }
     days_until_shipping_id { '2' }
     price                  { '711480' }

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Item, type: :model do
 
   describe '商品出品機能' do
     context '商品出品がうまくいくとき' do
-      it 'image/name/explanation/category_id/status_id/shipping_charges_id/shipping_region_id/days_until_shipping_id/price/user_idが存在すれば登録できる' do
+      it 'image/name/explanation/category_id/status_id/shipping_charge_id/shipping_region_id/days_until_shipping_id/price/user_idが存在すれば登録できる' do
         expect(@item).to be_valid
       end
     end
@@ -39,10 +39,10 @@ RSpec.describe Item, type: :model do
         @item.valid?
         expect(@item.errors.full_messages).to include('Status Select')
       end
-      it 'shipping_charges_idが1（発送料の負担が未選択）だと登録できない' do
-        @item.shipping_charges_id = '1'
+      it 'shipping_charge_idが1（発送料の負担が未選択）だと登録できない' do
+        @item.shipping_charge_id = '1'
         @item.valid?
-        expect(@item.errors.full_messages).to include('Shipping charges Select')
+        expect(@item.errors.full_messages).to include('Shipping charge Select')
       end
       it 'shipping_region_idが1（発送元の地域が未選択）だと登録できない' do
         @item.shipping_region_id = '1'


### PR DESCRIPTION
#What
商品詳細画面の編集
Itemコントローラの編集

※ActiveHashからデータを取り出す処理を実装するに当たり、Itemテーブルのカラム名を変更する必要があったため変更しております。
shipping_charges_id → shipping_charge_id

#Why
商品詳細表示機能実装のため

機能の様子を撮影したgifはこちらになります。
他者の出品した商品詳細画面
https://gyazo.com/025f44a36fdfcb47ae42f9bc6746bbc5

自分の出品した商品詳細画面
https://gyazo.com/50df5e25aef7a25583d5a930b1ec9ebd

レビューよろしくお願いいたします。